### PR TITLE
Feature reduce time gaps

### DIFF
--- a/.config
+++ b/.config
@@ -188,6 +188,10 @@ upload_queue_file: FILES_TO_UPLOAD.inf
 ;     4 - Skip FRs, but upload everything else.
 upload_mode: 1
 
+; If the gap between fits files is greater than the number of seconds shown below
+; fits files will be brought in from the captured_night_dir
+max_time_between_fits: 3600
+
 ; Upload events on demand
 event_monitor_enabled: true
 ; Webpage to retrieve watchlist from

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -104,8 +104,6 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
 
             # iterate across this interval, missing the first - because that fits file is already in place
             # and add target times for fits files to find
-            print("Interval seconds {}".format(interval_seconds))
-            print("Time elapsed     {}".format(time_elapsed))
 
             # intialise target_time for edge case protection
             target_time = time_previous_fits_file + datetime.timedelta(seconds=interval_seconds)

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -68,13 +68,9 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
     original_fits_list_length = len(fits_list)
 
     first_captured_fits_file = os.path.basename(captured_fits_list[0])
-    log.info("First fits file : {}".format(first_captured_fits_file))
     time_previous_fits_file = RMS.Formats.FFfile.filenameToDatetime(first_captured_fits_file)
-    log.info("Time of first file {}".format(time_previous_fits_file))
     final_captured_fits_file = os.path.basename(captured_fits_list[-1])
-    log.info("Final fits file : {}".format(final_captured_fits_file))
     time_final_fits_file = RMS.Formats.FFfile.filenameToDatetime(final_captured_fits_file)
-    log.info("Time of final file {}".format(time_final_fits_file))
 
     # add the final captured file to the fits list
     fits_list.append(final_captured_fits_file)
@@ -122,7 +118,6 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
     for target_time in target_time_list:
         for fits_file in captured_fits_list:
             if RMS.Formats.FFfile.filenameToDatetime(os.path.basename(fits_file)) > target_time:
-                log.info("Adding {} to the files to be uploaded".format(fits_file))
                 file_list.append(os.path.basename(fits_file))
                 break
 

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -381,10 +381,10 @@ def archiveDetections(captured_path, archived_path, ff_detected, config, extra_f
         log.error("".join(traceback.format_exception(*sys.exc_info())))
 
     if config.upload_mode == 1:
-        #try:
+        try:
             file_list = reduceTimeGaps(file_list, captured_path, config.max_time_between_fits)
-        #except:
-        #   log.warning("Could not reduce time gaps")
+        except:
+            log.warning("Could not reduce time gaps")
 
     if file_list:
 

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -41,6 +41,7 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
 
     if max_time_between_fits < minimum_time_between_fits:
         log.warning("Setting max_time_between_fits to {} seconds is less than coded minimum of {} seconds".format(max_time_between_fits, minimum_time_between_fits))
+        max_time_between_fits = minimum_time_between_fits
     log.info("max_time_between_fits is set to {} seconds".format(max_time_between_fits))
 
     # make a list of only fits files, sorted by time

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -98,20 +98,21 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
         if time_elapsed > max_time_between_fits:
             # work out how many intervals there are
             number_of_additional_files = time_elapsed // max_time_between_fits
-            # how long is this interval
-            interval_seconds = int(time_elapsed // (number_of_additional_files+1))
+            # how long is the interval, make 1 second shorter so that we will always add at least one file at middle
+            # of interval, for proteciton against edge case
+            interval_seconds = int(time_elapsed // (number_of_additional_files+1) -1)
 
             # iterate across this interval, missing the first - because that fits file is already in place
             # and add target times for fits files to find
             print("Interval seconds {}".format(interval_seconds))
             print("Time elapsed     {}".format(time_elapsed))
 
-            # intialise target_time for safety
+            # intialise target_time for edge case protection
             target_time = time_previous_fits_file + datetime.timedelta(seconds=interval_seconds)
 
-            # in case some edge case prevents this loop from executing
+
             files_added = 0
-            for offset in range(interval_seconds,time_elapsed - interval_seconds,interval_seconds):
+            for offset in range(interval_seconds + 1,time_elapsed - interval_seconds,interval_seconds):
                 target_time = time_previous_fits_file + datetime.timedelta(seconds = offset)
                 target_time_list.append(target_time)
                 files_added += 1

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -99,10 +99,13 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
             # work out how many intervals there are
             number_of_additional_files = time_elapsed // max_time_between_fits
             # how long is this interval
-            interval_seconds = int(time_elapsed // (number_of_additional_files + 1))
+            interval_seconds = int(time_elapsed // (number_of_additional_files+1))
 
             # iterate across this interval, missing the first - because that fits file is already in place
             # and add target times for fits files to find
+            print("Interval seconds {}".format(interval_seconds))
+            print("Time elapsed     {}".format(time_elapsed))
+
             for offset in range(interval_seconds,time_elapsed - interval_seconds,interval_seconds):
                 target_time = time_previous_fits_file + datetime.timedelta(seconds = offset)
                 target_time_list.append(target_time)

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -37,7 +37,11 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
 
 
     fits_list = []
+    minimum_time_between_fits = 900
 
+    if max_time_between_fits < minimum_time_between_fits:
+        log.warning("Setting max_time_between_fits to {} seconds is less than coded minimum of {} seconds".format(max_time_between_fits, minimum_time_between_fits))
+    log.info("max_time_between_fits is set to {} seconds".format(max_time_between_fits))
 
     # make a list of only fits files, sorted by time
     for path_file_to_check in file_list:
@@ -367,7 +371,7 @@ def archiveDetections(captured_path, archived_path, ff_detected, config, extra_f
 
     if config.upload_mode == 1:
         try:
-            file_list = reduceTimeGaps(file_list, captured_path)
+            file_list = reduceTimeGaps(file_list, captured_path, config.max_time_between_fits)
         except:
             log.warning("Could not reduce time gaps")
 

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -119,9 +119,9 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
             if files_added == 0:
                 log.warning("Loop did not execute with input values of")
                 log.warning("time_of_this_fits_file {}".format(time_of_this_fits_file))
-                log.warning("time_elapsed".format(time_elapsed))
-                log.warning("number_of_additional_fits_files".format(number_of_additional_files))
-                log.warning("interval_seconds".format(interval_seconds))
+                log.warning("time_elapsed {}".format(time_elapsed))
+                log.warning("number_of_additional_fits_files {}".format(number_of_additional_files))
+                log.warning("interval_seconds {}".format(interval_seconds))
 
             # the time of the previous fits file is the time of the file we are going to add
             time_previous_fits_file = target_time

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -136,8 +136,8 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
 
     log.info("Maximum interval before including extra files was {} seconds".format(initial_max_interval))
     log.info("Maximum interval after including {} extra files is {} seconds".format(len(target_time_list),final_max_interval))
-    log.info("Original fits file count {}".format(original_fits_list_length))
-    log.info("Final fits file count    {}".format(final_fits_count))
+    log.info("Original / final fits file count {}/{}".format(original_fits_list_length, final_fits_count))
+
 
     return file_list
 
@@ -366,10 +366,10 @@ def archiveDetections(captured_path, archived_path, ff_detected, config, extra_f
         log.error("".join(traceback.format_exception(*sys.exc_info())))
 
     if config.upload_mode == 1:
-        try:
+        #try:
             file_list = reduceTimeGaps(file_list, captured_path, config.max_time_between_fits)
-        except:
-            log.warning("Could not reduce time gaps")
+        #except:
+        #   log.warning("Could not reduce time gaps")
 
     if file_list:
 

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -49,7 +49,7 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
         file_to_check = os.path.basename(path_file_to_check)
         if file_to_check.endswith('.fits'):
             fits_list.append(file_to_check)
-            log.info("{}".format(os.path.basename(file_to_check)))
+            # log.info("Adding {}".format(os.path.basename(file_to_check)))
     fits_list.sort()
 
     # get a list of all the fits files that are available in the captured files directory, and sort

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -106,9 +106,22 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
             print("Interval seconds {}".format(interval_seconds))
             print("Time elapsed     {}".format(time_elapsed))
 
+            # intialise target_time for safety
+            target_time = time_previous_fits_file + datetime.timedelta(seconds=interval_seconds)
+
+            # in case some edge case prevents this loop from executing
+            files_added = 0
             for offset in range(interval_seconds,time_elapsed - interval_seconds,interval_seconds):
                 target_time = time_previous_fits_file + datetime.timedelta(seconds = offset)
                 target_time_list.append(target_time)
+                files_added += 1
+
+            if files_added == 0:
+                log.warning("Loop did not execute with input values of")
+                log.warning("time_of_this_fits_file {}".format(time_of_this_fits_file))
+                log.warning("time_elapsed".format(time_elapsed))
+                log.warning("number_of_additional_fits_files".format(number_of_additional_files))
+                log.warning("interval_seconds".format(interval_seconds))
 
             # the time of the previous fits file is the time of the file we are going to add
             time_previous_fits_file = target_time

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -49,7 +49,7 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
         file_to_check = os.path.basename(path_file_to_check)
         if file_to_check.endswith('.fits'):
             fits_list.append(file_to_check)
-            # log.info("Adding {}".format(os.path.basename(file_to_check)))
+
     fits_list.sort()
 
     # get a list of all the fits files that are available in the captured files directory, and sort

--- a/RMS/ArchiveDetections.py
+++ b/RMS/ArchiveDetections.py
@@ -151,7 +151,7 @@ def reduceTimeGaps(file_list, captured_path, max_time_between_fits = 900):
 
     log.info("Maximum interval before including extra files was {} seconds".format(initial_max_interval))
     log.info("Maximum interval after including {} extra files is {} seconds".format(len(target_time_list),final_max_interval))
-    log.info("Original / final fits file count {}/{}".format(original_fits_list_length, final_fits_count))
+    log.info("Original / final fits file count {} / {}".format(original_fits_list_length, final_fits_count))
 
 
     return file_list

--- a/RMS/ConfigReader.py
+++ b/RMS/ConfigReader.py
@@ -364,6 +364,8 @@ class Config:
         # 1 - Normal, 2 - Skip uploading FFs, 3 - Skip FFs and FRs
         self.upload_mode = 1
 
+        self.max_time_between_fits = 3600
+
         self.event_monitor_enabled = True
         self.event_monitor_db_name = "event_monitor.db"
         self.event_monitor_webpage = "https://globalmeteornetwork.org/events/event_watchlist.txt"
@@ -1042,9 +1044,13 @@ def parseUpload(config, parser):
     if parser.has_option(section, "remote_dir"):
         config.remote_dir = parser.get(section, "remote_dir")
 
-    # SSH port
+    # Upload mode
     if parser.has_option(section, "upload_mode"):
         config.upload_mode = parser.getint(section, "upload_mode")
+
+    # Max time between fits
+    if parser.has_option(section, "max_time_between_fits"):
+        config.max_time_between_fits = parser.getint(section, "max_time_between_fits")
 
     # Event monitor enabled
     if parser.has_option(section, "event_monitor_enabled"):

--- a/RMS/Reprocess.py
+++ b/RMS/Reprocess.py
@@ -449,7 +449,7 @@ def processNight(night_data_dir, config, detection_results=None, nodetect=False)
     # If FFs are not uploaded, choose two to upload
     if config.upload_mode > 1:
     
-        # If all FF files are not uploaded, add two FF files which were successfuly recalibrated
+        # If all FF files are not uploaded, add two FF files which were successfully recalibrated
         recalibrated_ffs = []
         for ff_name in recalibrated_platepars:
 


### PR DESCRIPTION
This pull request is related to #270. 

At the end of processing, and just prior to generating the archive, the spacing between the fits files is analysed. 

If the gap between any pair of fits files, or the start of capture and the first fits file, or the last fits file and the end of capture is greater than the max_time_between_fits setting given in the .config file

```
; If the gap between fits files is greater than the number of seconds shown below
; fits files will be brought in from the captured_night_dir
max_time_between_fits: 3600
```

Then the gap is divided into the fewest possible evenly spaced intervals, and then fits files are brought in from night_captured_dir.

The default setting of 3600 seconds, 1 hour produces

```
2024/02/18 01:38:21-INFO-ArchiveDetections-line:45 - max_time_between_fits is set to 3600 seconds
2024/02/18 01:38:21-INFO-ArchiveDetections-line:152 - Maximum interval before including extra files was 3434 seconds
2024/02/18 01:38:21-INFO-ArchiveDetections-line:153 - Maximum interval after including 0 extra files is 3434 seconds
2024/02/18 01:38:21-INFO-ArchiveDetections-line:154 - Original / final fits file count 7 / 7
```

Which in this case, did not require any files to be added.

If very low settings are given in the .config file, they are overridden by a hard coded minimum of 900 seconds, or 15 minutes. 

for example in the .config file

```
; If the gap between fits files is greater than the number of seconds shown below
; fits files will be brought in from the captured_night_dir
max_time_between_fits: 700
```

produces the log output 

```
2024/02/18 01:28:57-WARNING-ArchiveDetections-line:43 - Setting max_time_between_fits to 700 seconds is less than coded minimum of 900 seconds
2024/02/18 01:28:57-INFO-ArchiveDetections-line:45 - max_time_between_fits is set to 900 seconds
2024/02/18 01:28:57-INFO-ArchiveDetections-line:152 - Maximum interval before including extra files was 3434 seconds
2024/02/18 01:28:57-INFO-ArchiveDetections-line:153 - Maximum interval after including 11 extra files is 902 seconds
2024/02/18 01:28:57-INFO-ArchiveDetections-line:154 - Original / final fits file count 7 / 18
```

A less extreme configuration of 1800 seconds, 30 minutes gives the following output

```
2024/02/18 01:33:00-INFO-ArchiveDetections-line:45 - max_time_between_fits is set to 1800 seconds
2024/02/18 01:33:00-INFO-ArchiveDetections-line:152 - Maximum interval before including extra files was 3434 seconds
2024/02/18 01:33:00-INFO-ArchiveDetections-line:153 - Maximum interval after including 5 extra files is 1793 seconds
2024/02/18 01:33:00-INFO-ArchiveDetections-line:154 - Original / final fits file count 7 / 12
```
